### PR TITLE
- Release v2.1.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 2.0.1
+next-version: 2.1.0
 tag-prefix: '[vV]'
 mode: ContinuousDeployment
 branches:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/CodeShayk/Schemio/blob/master/Images/ninja-icon-16.png" alt="ninja" style="width:30px;"/> Schemio v2.0.1
+# <img src="https://github.com/CodeShayk/Schemio/blob/master/Images/ninja-icon-16.png" alt="ninja" style="width:30px;"/> Schemio v2.1.0
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/CodeShayk/Schemio/blob/master/LICENSE.md) 
 [![Master-Build](https://github.com/CodeShayk/Schemio/actions/workflows/Build-Master.yml/badge.svg)](https://github.com/CodeShayk/Schemio/actions/workflows/Build-Master.yml) 
 [![GitHub Release](https://img.shields.io/github/v/release/CodeShayk/Schemio?logo=github&sort=semver)](https://github.com/CodeShayk/Schemio/releases/latest)

--- a/src/Schemio.API/Schemio.API.csproj
+++ b/src/Schemio.API/Schemio.API.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/CodeShayk/Schemio</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>graphql data json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio-Api data-aggregator</PackageTags>
+    <PackageTags>graphql data json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio-api data-aggregator</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>

--- a/src/Schemio.API/Schemio.API.csproj
+++ b/src/Schemio.API/Schemio.API.csproj
@@ -4,23 +4,27 @@
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net9.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Nullable>disable</Nullable>
-    <Title>Schemio with EntityFramework</Title>
+    <Title>Schemio with Web API</Title>
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
-    <Description>.Net Library to hydrate data entities by object graph using schema paths (supports XPath &amp; JSONPath). Supports Web API using HttpClient. </Description>
+    <Description>Schemio is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings. This package provides support for Web API using HttpClient. </Description>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
-    <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki/i.-Home</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki</PackageProjectUrl>
     <PackageIcon>ninja-icon-16.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/CodeShayk/Schemio</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>graphql json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio-Api HttpCliet</PackageTags>
+    <PackageTags>graphql data json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio-Api data-aggregator</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
+    <PackageReleaseNotes>
+      v2.1.0 - Targets .net 4.6.2, .net standard 2.0, .net standard 2.1 and .net 9.0.
+      - Provides Pre and Post Transform hooks.
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Schemio.Core/Schemio.Core.csproj
+++ b/src/Schemio.Core/Schemio.Core.csproj
@@ -12,22 +12,19 @@
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ninja-icon-16.png</PackageIcon>
-    <Description>.Net Library to hydrate data entities by object graph using schema paths (supports XPath &amp; JSONPath).</Description>
-    <PackageTags>graphql json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio schemio-core</PackageTags>
-    <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki/i.-Home</PackageProjectUrl>
+    <Description>Schemio is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings.</Description>
+    <PackageTags>graphql data json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio schemio-core data-aggregator</PackageTags>
+    <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Title>Schemio (No Query Engine Provided)</Title>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>2.0.1</Version>
-    <PackageReleaseNotes> Targets .net 4.6.2, .net standard 2.0, .net standard 2.1 and .net 9.0.
-- `Entity Schema` renamed to `Entity Configuration` and requires implementing `EntityContfiguration&lt;TEntity&gt;`.
-- `IRootQuery`, `IChildQuery`, `BaseRootQuery&lt;TParameter, TResult&gt;` &amp; `BaseChildQuery&lt;TParameter,TResult&gt;` removed.
-- Both Parent and child queries need to implement `BaseQuery&lt;TResult&gt;` and provide override for `isContextResolved()` and `ResolveQuery()` methods.
-- `IoC` registration streamlined with `fluent interface` for container configuration.
-- Renamed `IEntityContext` to `IEntityRequest`.</PackageReleaseNotes>
+    <Version>2.1.0</Version>
+    <PackageReleaseNotes> v2.1.0 - Targets .net 4.6.2, .net standard 2.0, .net standard 2.1 and .net 9.0.
+      - Provides Pre and Post Transform hooks.
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Schemio.EntityFramework/Schemio.EntityFramework.csproj
+++ b/src/Schemio.EntityFramework/Schemio.EntityFramework.csproj
@@ -8,7 +8,7 @@
     <Title>Schemio with EntityFramework</Title>
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
-    <Description>Schemio is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings.This package provides support for Entity Framework for querying database. </Description>
+    <Description>Schemio is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings. This package provides support for Entity Framework for querying database. </Description>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
     <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki</PackageProjectUrl>
     <PackageIcon>ninja-icon-16.png</PackageIcon>

--- a/src/Schemio.EntityFramework/Schemio.EntityFramework.csproj
+++ b/src/Schemio.EntityFramework/Schemio.EntityFramework.csproj
@@ -8,20 +8,24 @@
     <Title>Schemio with EntityFramework</Title>
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
-    <Description>.Net Library to hydrate data entities by object graph using schema paths (supports XPath &amp; JSONPath). Supports Entity Framework for querying database. </Description>
+    <Description>Schemio is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings.This package provides support for Entity Framework for querying database. </Description>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
-    <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki/i.-Home</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki</PackageProjectUrl>
     <PackageIcon>ninja-icon-16.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/CodeShayk/Schemio</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>graphql json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio-entity-framework entity-framework</PackageTags>
+    <PackageTags>graphql data json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio-entity-framework entity-framework data-aggregator</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
+    <PackageReleaseNotes>
+      v2.1.0 - Targets .net 9.0.
+      - Provides Pre and Post Transform hooks.
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Schemio.SQL/Schemio.SQL.csproj
+++ b/src/Schemio.SQL/Schemio.SQL.csproj
@@ -15,7 +15,7 @@
     <PackageIcon>ninja-icon-16.png</PackageIcon>
     <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki</PackageProjectUrl>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
-    <Description>Schemio is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings.This package provides support for Entity Framework for querying database.This package provides support for Dapper to query SQL database. </Description>   
+    <Description>Schemio is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings. This package provides support for Dapper to query SQL databases.</Description>   
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>

--- a/src/Schemio.SQL/Schemio.SQL.csproj
+++ b/src/Schemio.SQL/Schemio.SQL.csproj
@@ -8,20 +8,24 @@
     <Title>Schemio with SQL</Title>
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
-    <PackageTags>graphql json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio-sql dapper-sql dapper</PackageTags>
+    <PackageTags>graphql data json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch schemio-sql dapper-sql dapper data-aggregator</PackageTags>
     <RepositoryUrl>https://github.com/CodeShayk/Schemio</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ninja-icon-16.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki/i.-Home</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/CodeShayk/Schemio/wiki</PackageProjectUrl>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
-    <Description>.Net Library to hydrate data entities by object graph using schema paths (supports XPath &amp; JSONPath). Supports Dapper for querying SQL database. </Description>   
+    <Description>Schemio is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings.This package provides support for Entity Framework for querying database.This package provides support for Dapper to query SQL database. </Description>   
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
+    <PackageReleaseNotes>
+      v2.1.0 - Targets .net 4.6.2, .net standard 2.0, .net standard 2.1 and .net 9.0.
+      - Provides Pre and Post Transform hooks.
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
## Release Notes

### Changes in Schemio.Core - Targets .Net Framework 4.6.2; .Net Standards 2.0 & 2.1; .Net 9.0.
- Provides support for Pre and Post transform hooks.

### Changes in Schemio.SQL -  Targets .Net Framework 4.6.2; .Net Standards 2.1; .Net 9.0.
- Provides support for Pre and Post transform hooks.

### Changes in Schemio.EntityFramework -  Targets .Net 9.0.
- Provides support for Pre and Post transform hooks.

### Changes in Schemio.API - Targets .Net Framework 4.6.2; .Net Standards 2.0 & 2.1; .Net 9.0.
- Provides support for Pre and Post transform hooks.

## Developer Guide
`Important`: Please see Developer Guide [here ](https://github.com/CodeShayk/Schemio/wiki) for more details.

